### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ module "mod_azmaps" {
 |------|------|
 | [azurerm_maps_account.maps_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_account) | resource |
 | [azurerm_maps_creator.maps_creator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_creator) | resource |
-| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Maps Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-azmaps/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-azmaps/azurerm/)
 
-This Overlay terraform module can create a an [Azure Maps](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-overview) account with [Azure Maps Creator](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) and [Azure Maps Data Reader](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) roles to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay terraform module can create a an [Azure Maps](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-overview) account with [Azure Maps Creator](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) and [Azure Maps Data Reader](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) roles to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -63,22 +63,22 @@ module "mod_azmaps" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_maps_rg"></a> [mod\_maps\_rg](#module\_mod\_maps\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_maps_rg"></a> [mod\_maps\_rg](#module\_mod\_maps\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -86,8 +86,8 @@ module "mod_azmaps" {
 |------|------|
 | [azurerm_maps_account.maps_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_account) | resource |
 | [azurerm_maps_creator.maps_creator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_creator) | resource |
-| [azurenoopsutils_resource_name.maps_account](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.maps_creator](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,8 +86,8 @@ module "mod_azmaps" {
 |------|------|
 | [azurerm_maps_account.maps_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_account) | resource |
 | [azurerm_maps_creator.maps_creator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_creator) | resource |
-| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Maps Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-azmaps/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-azmaps/azurerm/)
 
-This Overlay terraform module can create a an [Azure Maps](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-overview) account with [Azure Maps Creator](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) and [Azure Maps Data Reader](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) roles to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay terraform module can create a an [Azure Maps](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-overview) account with [Azure Maps Creator](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) and [Azure Maps Data Reader](https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-create-data) roles to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -63,22 +63,22 @@ module "mod_azmaps" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_maps_rg"></a> [mod\_maps\_rg](#module\_mod\_maps\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_maps_rg"></a> [mod\_maps\_rg](#module\_mod\_maps\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -86,8 +86,8 @@ module "mod_azmaps" {
 |------|------|
 | [azurerm_maps_account.maps_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_account) | resource |
 | [azurerm_maps_creator.maps_creator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/maps_creator) | resource |
-| [azurenoopsutils_resource_name.maps_account](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.maps_creator](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.maps_creator](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,6 +8,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_maps_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_maps_rg.*.resource_group_location, [""]), 0)
-  maps_account_name   = coalesce(var.maps_account_custom_name, data.azurenoopsutils_resource_name.maps_account.result)
-  maps_creator_name   = coalesce(var.maps_creator_custom_name, data.azurenoopsutils_resource_name.maps_creator.result)
+  maps_account_name   = coalesce(var.maps_account_custom_name, data.popsrox_resource_name.maps_account.result)
+  maps_creator_name   = coalesce(var.maps_creator_custom_name, data.popsrox_resource_name.maps_creator.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "maps_account" {
+data "popsrox_resource_name" "maps_account" {
   name          = var.workload_name
   resource_type = "azurerm_maps_account"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -11,7 +11,7 @@ data "azurenoopsutils_resource_name" "maps_account" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "maps_creator" {
+data "popsrox_resource_name" "maps_creator" {
   name          = var.workload_name
   resource_type = "azurerm_maps_account"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops` org references and the `azurenoopsutils` provider with the `POps-Rox`/`popsrox-utils` equivalents across the module.

## Changes
- `versions.tf`: renamed provider block from `azurenoopsutils` to `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: renamed data source type from `azurenoopsutils_resource_name` to `popsrox_resource_name`
- `locals.naming.tf`: updated data source references to match new type name
- `README.md`: scrubbed all `azurenoops` org refs (badge URLs, provider table, module table, data-source table)
- `docs/index.md`: same scrub as README.md

## Testing
- `terraform fmt -recursive` passes with no changes
- No remaining `azurenoops` references in tracked files

Closes #7