### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-azmaps
+  name: terraform-az-overlays-azmaps
   description: Terraform overlay module for Azure Maps
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-azmaps
+    github.com/project-slug: POps-Rox/terraform-az-overlays-azmaps
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-azmaps
+    - url: https://github.com/POps-Rox/terraform-az-overlays-azmaps
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/basic_maps/main.tf
+++ b/examples/basic_maps/main.tf
@@ -5,14 +5,14 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }
 
 module "mod_az_maps" {
   source = "../.."
-  #source  = "github.com/POps-Rox/tf-az-overlays-azmaps"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-azmaps"
   #version = "x.x.x"
 
   # By default, this module will create a resource group and 

--- a/scaffolding.tf
+++ b/scaffolding.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_maps_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_maps_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.